### PR TITLE
Only highlight "supported" languages and fix typescript details hl

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ return {
 					-- Or "vtsls", their information is different, so we
 					-- need to know in advance.
 					ls = "typescript-language-server",
+					extra_info_hl = "@comment",
 				},
 				rust = {
 					-- such as (as Iterator), (use std::io).
@@ -47,6 +48,9 @@ return {
 					-- such as "From <stdio.h>"
 					extra_info_hl = "@comment",
 				},
+
+                                -- If we should try to highlight "not supported" languages
+                                fallback = true,
 			},
 			-- If the built-in logic fails to find a suitable highlight group,
 			-- this highlight is applied to the label.

--- a/lua/colorful-menu/init.lua
+++ b/lua/colorful-menu/init.lua
@@ -13,6 +13,7 @@ local default_config = {
 			-- Or "vtsls", their information is different, so we
 			-- need to know in advance.
 			ls = "typescript-language-server",
+			extra_info_hl = "@comment",
 		},
 		rust = {
 			-- such as (as Iterator), (use std::io).
@@ -351,14 +352,23 @@ function M.typescript_language_server_label_for_completion(item, language)
 		highlight_name = M.config.fallback_highlight
 	end
 
+	local highlights = {
+		{
+			highlight_name,
+			range = { 0, #label },
+		},
+	}
+
+	if detail then
+		table.insert(highlights, {
+			M.config.ft.typescript.extra_info_hl,
+			range = { #label + 1, #label + 1 + #detail },
+		})
+	end
+
 	return {
 		text = text,
-		highlights = {
-			{
-				highlight_name,
-				range = { 0, #label },
-			},
-		},
+		highlights = highlights,
 	}
 end
 

--- a/lua/colorful-menu/init.lua
+++ b/lua/colorful-menu/init.lua
@@ -127,7 +127,7 @@ function M.highlights(completion_item, ft)
 			return
 		end
 	else
-		item = { text = completion_item.label }
+		return nil
 	end
 
 	M.apply_post_processing(item)

--- a/lua/colorful-menu/init.lua
+++ b/lua/colorful-menu/init.lua
@@ -29,6 +29,7 @@ local default_config = {
 				-- [6] = function(completion_item) end, -- 6 = Variable
 			},
 		},
+		fallback = true,
 	},
 	fallback_highlight = "@variable",
 	max_width = 60,
@@ -127,7 +128,12 @@ function M.highlights(completion_item, ft)
 			return
 		end
 	else
-		return nil
+		-- No languages detected so check if we should highlight with default or not
+		if not M.config.ft.fallback then
+			return nil
+		end
+
+		item = M.default_highlight(completion_item, ft)
 	end
 
 	M.apply_post_processing(item)
@@ -169,6 +175,14 @@ function M.rust_compute_completion_highlights(completion_item, ft)
 		end
 	end
 	return vim_item
+end
+
+function M.default_highlight(completion_item, ft)
+	local label = completion_item.label
+	if label == nil then
+		return ""
+	end
+	return M.highlight_range(label, ft, 0, #label - 1)
 end
 
 function M._rust_compute_completion_highlights(completion_item, ft)

--- a/lua/colorful-menu/init.lua
+++ b/lua/colorful-menu/init.lua
@@ -127,7 +127,7 @@ function M.highlights(completion_item, ft)
 			return
 		end
 	else
-		item = M.defaut_highlight(completion_item, ft)
+		item = { text = completion_item.label }
 	end
 
 	M.apply_post_processing(item)
@@ -169,14 +169,6 @@ function M.rust_compute_completion_highlights(completion_item, ft)
 		end
 	end
 	return vim_item
-end
-
-function M.defaut_highlight(completion_item, ft)
-	local label = completion_item.label
-	if label == nil then
-		return ""
-	end
-	return M.highlight_range(label, ft, 0, #label - 1)
 end
 
 function M._rust_compute_completion_highlights(completion_item, ft)


### PR DESCRIPTION
So this is my proposal and will close #2 

I see that you found a way to use blink.cmp with this and lspkind is only for `cmp` at least for now, so I agree we can just leave the trimming of the line.

My proposal is to just do nothing except for the post processing if the language is not "supported"