### PR TITLE
builtin support for zig

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ to lspkind.nvim.
 run `nvim  -u ~/.config/nvim/repro.lua ~/.config/nvim/repro.lua` as a minimal reproduce template
 see [repro.lua](https://github.com/xzbdmw/colorful-menu.nvim/blob/master/repro.lua)
 
-Has built-in supports for **rust-analyzer(rust)**, **gopls(go)**, **typescript-language-server/vtsls**, **lua-ls**, **clangd(C)**, **intelephense(php)**, for any other language, default to directly
+Has built-in supports for **rust-analyzer(rust)**, **gopls(go)**, **typescript-language-server/vtsls**, **lua-ls**, **clangd(C)**, **intelephense(php)**, **zls(zig)** for any other language, default to directly
 apply treesitter highlight to label (feel free to open feature request for more languages).
 
 Currently supports **nvim-cmp** and **blink.cmp**.


### PR DESCRIPTION
So far so good, one thing is zig reports module such as `std` as type `Struct` and detail `type`, so I cant distinguish real Type and module type.

<img width="978" alt="image" src="https://github.com/user-attachments/assets/71126826-6f79-48f1-9d11-83e1955327ef" />

