### PR TITLE
feat: add roslyn support

### DIFF
--- a/lua/colorful-menu/init.lua
+++ b/lua/colorful-menu/init.lua
@@ -42,6 +42,9 @@ M.config = {
             -- Such as "From <stdio.h>".
             extra_info_hl = "@comment",
         },
+        roslyn = {
+            extra_info_hl = "@comment",
+        },
         fallback = true,
     },
     fallback_highlight = "@variable",
@@ -185,6 +188,9 @@ function M.highlights(completion_item, ls)
         --
     elseif ls == "intelephense" then
         item = require("colorful-menu.languages.php").intelephense(completion_item, ls)
+        --
+    elseif ls == "roslyn" then
+        item = require("colorful-menu.languages.cs").roslyn(completion_item, ls)
         --
     else
         -- No languages detected so check if we should highlight with default or not

--- a/lua/colorful-menu/languages/cs.lua
+++ b/lua/colorful-menu/languages/cs.lua
@@ -1,0 +1,59 @@
+local utils = require("colorful-menu.utils")
+local Kind = require("colorful-menu").Kind
+local config = require("colorful-menu").config
+
+local M = {}
+
+---@param completion_item lsp.CompletionItem
+---@param ls string
+---@return CMHighlights
+function M.roslyn(completion_item, ls)
+    local label = completion_item.label
+    local description = completion_item.labelDetails and completion_item.labelDetails.description
+    local kind = completion_item.kind
+
+    local text = label
+
+    if not kind then
+        return utils.highlight_range(text, ls, 0, #text)
+    end
+
+    local highlight_name
+    if kind == Kind.Class or kind == Kind.Interface or kind == Kind.Enum then
+        highlight_name = "@type"
+    elseif kind == Kind.Constructor then
+        highlight_name = "@type"
+    elseif kind == Kind.Constant then
+        highlight_name = "@constant"
+    elseif kind == Kind.Function or kind == Kind.Method then
+        highlight_name = "@function"
+    elseif kind == Kind.Property or kind == Kind.Field then
+        highlight_name = "@property"
+    elseif kind == Kind.Variable then
+        highlight_name = "@variable"
+    else
+        highlight_name = config.fallback_highlight
+    end
+
+    local highlights = {
+        {
+            highlight_name,
+            range = { 0, #label },
+        },
+    }
+
+    if description then
+        text = label .. " " .. description
+        table.insert(highlights, {
+            config.ls.roslyn.extra_info_hl,
+            range = { #label + 1, #text },
+        })
+    end
+
+    return {
+        text = text,
+        highlights = highlights,
+    }
+end
+
+return M


### PR DESCRIPTION
I am maintaining a plugin for C# dev in neovim which uses the `roslyn` language server. This PR adds support for that.

Unfortunately it doesn't seem like it sends a lot of information like function arguments and such as part of the response, so it will not look as pretty as other languages, but at least it sends some small description that may be nice to have.

I also just highlighted the different kinds as it is done for ts_ls in this plugin.

Before:

<img width="605" alt="image" src="https://github.com/user-attachments/assets/aaf85a83-818c-481b-9295-54a9baa8cf13" />

After:

<img width="826" alt="image" src="https://github.com/user-attachments/assets/40ae83aa-58ee-4195-b15b-375bf03881c1" />

Another thing:

I was thinking that it would maybe be nice to have a way to disable this plugin for certain languages where the user might not enjoy how it looks. However, I was unsure about how a config option should be for that. Was thinking maybe an `enabled = true/false` for each of the different `ls` in the config?