### PR TITLE
feat: fractional `max_width` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ return {
             fallback_highlight = "@variable",
             -- If provided, the plugin truncates the final displayed text to
             -- this width (measured in display cells). Any highlights that extend
-            -- beyond the truncation point are ignored. Default 60.
+            -- beyond the truncation point are ignored. When set to a float
+            -- between 0 and 1, it'll be treated as percentage of the width of
+            -- the window: math.floor(max_width * vim.api.nvim_win_get_width(0))
+            -- Default 60.
             max_width = 60,
         })
     end,

--- a/lua/colorful-menu/init.lua
+++ b/lua/colorful-menu/init.lua
@@ -125,6 +125,9 @@ local function apply_post_processing(item)
 
     if max_width and max_width > 0 then
         -- if text length is beyond max_width, truncate
+        if max_width < 1 and max_width > 0 then
+            max_width = math.floor(max_width * vim.api.nvim_win_get_width(0))
+        end
         local display_width = vim.fn.strdisplaywidth(text)
         if display_width > max_width then
             -- We can remove from the end


### PR DESCRIPTION
This PR allows configuring the `max_width` option to be a fraction of the window's width (like 20%) and it'll reflect any changes in window dimensions (resizing splits or terminal emulators) because it retrieves the window width in real-time. It's a nice-to-have for any config shared on multiple machines with different display configurations.