### PR TITLE
Add custom configuration section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,35 @@ end
 ```
 </details>
 
+## Custom configuration with `lspkind.nvim`
+
+You can configure your completion engine (below is for `nvim-cmp` with both `colorful-menu.nvim` and `lspkind.nvim` to get completion menu like those in Screen section.
+
+```lua
+formatting = {
+  fields = { "kind", "abbr", "menu" },
+
+  format = function(entry, vim_item)
+    local kind = require("lspkind").cmp_format({
+        mode = "symbol_text",
+    })(entry, vim.deepcopy(vim_item))
+    local highlights_info = require("colorful-menu").cmp_highlights(entry)
+
+    -- if highlight_info==nil, which means missing ts parser, let's fallback to use default `vim_item.abbr`.
+    -- What this plugin offers is two fields: `vim_item.abbr_hl_group` and `vim_item.abbr`.
+    if highlights_info ~= nil then
+      vim_item.abbr_hl_group = highlights_info.highlights
+      vim_item.abbr = highlights_info.text
+    end
+    local strings = vim.split(kind.kind, "%s", { trimempty = true })
+    vim_item.kind = " " .. (strings[1] or "") .. " "
+    vim_item.menu = ""
+
+    return vim_item
+  end,
+}
+```
+
 ## Screen
 
 > **💡 Note:** You may want to set `CmpItemAbbrMatch` or `BlinkCmpLabelMatch` to only have **bold style** (without `fg`) to achieve a similar effect as the images below.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ end
 ## Custom configuration with `lspkind.nvim`
 
 You can configure your completion engine (below is for `nvim-cmp` with both `colorful-menu.nvim` and `lspkind.nvim` to get completion menu like those in Screen section.
+<details>
+<summary>Click to see</summary>
 
 ```lua
 formatting = {
@@ -228,11 +230,12 @@ formatting = {
     })(entry, vim.deepcopy(vim_item))
     local highlights_info = require("colorful-menu").cmp_highlights(entry)
 
-    -- if highlight_info==nil, which means missing ts parser, let's fallback to use default `vim_item.abbr`.
-    -- What this plugin offers is two fields: `vim_item.abbr_hl_group` and `vim_item.abbr`.
+    -- highlight_info is nil means we are missing the ts parser, it's
+    -- better to fallback to use default `vim_item.abbr`. What this plugin
+    -- offers is two fields: `vim_item.abbr_hl_group` and `vim_item.abbr`.
     if highlights_info ~= nil then
-      vim_item.abbr_hl_group = highlights_info.highlights
-      vim_item.abbr = highlights_info.text
+        vim_item.abbr_hl_group = highlights_info.highlights
+        vim_item.abbr = highlights_info.text
     end
     local strings = vim.split(kind.kind, "%s", { trimempty = true })
     vim_item.kind = " " .. (strings[1] or "") .. " "
@@ -242,6 +245,7 @@ formatting = {
   end,
 }
 ```
+</details>
 
 ## Screen
 


### PR DESCRIPTION
I tried to make completion menu look like this README, but cannot find how.
https://github.com/xzbdmw/colorful-menu.nvim/issues/24 explains, but it's hard to find.
Here the instruction on that issue is added to README for better discoverability.