### PR TITLE
Fix pretty end highlight

### DIFF
--- a/lua/colorful-menu/utils.lua
+++ b/lua/colorful-menu/utils.lua
@@ -360,13 +360,44 @@ function M.apply_post_processing(completion_item, item, ls)
             shift_color_by(item, long_label_width - short_label_width - string.len(pretty_end), long_label_width)
             item.text = item.text:sub(1, short_label_width) .. pretty_end .. item.text:sub(long_label_width + 1)
             if truncated_label then
-                table.insert(item.highlights, {
-                    "@comment",
-                    range = {
-                        short_label_width + (pretty_end == "(…)" and 1 or 0),
-                        short_label_width + (pretty_end == "(…)" and string.len("…)") or string.len("…")),
-                    },
-                })
+                if pretty_end == "(…)" then
+                    table.insert(item.highlights, {
+                        "@punctuation.bracket",
+                        range = {
+                            short_label_width,
+                            short_label_width + 1,
+                        },
+                    })
+                    table.insert(item.highlights, {
+                        "@comment",
+                        range = {
+                            short_label_width + 1,
+                            short_label_width + 4,
+                        },
+                    })
+                    table.insert(item.highlights, {
+                        "@punctuation.bracket",
+                        range = {
+                            short_label_width + 4,
+                            short_label_width + 5,
+                        },
+                    })
+                else -- pretty_end == "…)"
+                    table.insert(item.highlights, {
+                        "@comment",
+                        range = {
+                            short_label_width,
+                            short_label_width + 3,
+                        },
+                    })
+                    table.insert(item.highlights, {
+                        "@punctuation.bracket",
+                        range = {
+                            short_label_width + 3,
+                            short_label_width + 4,
+                        },
+                    })
+                end
             end
             cut_label(item, max_width, false)
         else
@@ -390,7 +421,11 @@ function M.apply_post_processing(completion_item, item, ls)
                 .. item.text:sub(long_label_width + 1)
             table.insert(item.highlights, {
                 "@comment",
-                range = { ascii_pos, ascii_pos + string.len("…)") - 1 },
+                range = { ascii_pos, ascii_pos + 3 },
+            })
+            table.insert(item.highlights, {
+                "@punctuation.bracket",
+                range = { ascii_pos + 3, ascii_pos + 4 },
             })
         end
     else


### PR DESCRIPTION
The last character of pretty end will not be highlighted correctly since the right bound of range is exclusive, intend to fix that.

Before
<img width="1550" height="741" alt="before" src="https://github.com/user-attachments/assets/0802a765-0ade-49d3-b1d6-303db84bd74b" />

After
<img width="1544" height="738" alt="after" src="https://github.com/user-attachments/assets/315fce61-585f-4d02-95f1-e3631f4ed4ba" />
